### PR TITLE
Chipset-Namen dürfen nun 100 Zeichen lang sein

### DIFF
--- a/lib/core/Chipset.class.php
+++ b/lib/core/Chipset.class.php
@@ -99,7 +99,7 @@
 		}
 		
 		public function setName($name) {
-			if(is_string($name) AND strlen($name)<=30) {
+			if(is_string($name) AND strlen($name)<=100) {
 				$this->name = $name;
 				return true;
 			}

--- a/netmon.sql
+++ b/netmon.sql
@@ -50,7 +50,7 @@ CREATE TABLE IF NOT EXISTS `chipsets` (
   `create_date` datetime NOT NULL,
   `update_date` datetime NOT NULL,
   `name` varchar(100) NOT NULL,
-  `hardware_name` varchar(30) NOT NULL,
+  `hardware_name` varchar(100) NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `name` (`name`),
   KEY `hardware_name` (`hardware_name`)

--- a/templates/base/html/config_edit_hardware_name.tpl.html
+++ b/templates/base/html/config_edit_hardware_name.tpl.html
@@ -8,10 +8,10 @@
 <h2>Chipset ändern</h2>
 <form action="./config.php?section=insert_edit_chipset_name&chipset_id={$smarty.get.chipset_id}" method="POST">
 	<p>
-		<b>Chipset:</b><br><input name="name" size="30" maxlength="30" value="{$chipset->getName()}">
+		<b>Chipset:</b><br><input name="name" size="40" maxlength="100" value="{$chipset->getName()}">
 	</p>
 	<p>
-		<b>Name:</b><br><input name="hardware_name" size="30" maxlength="30" value="{$chipset->getHardwareName()}">
+		<b>Name:</b><br><input name="hardware_name" size="40" maxlength="100" value="{$chipset->getHardwareName()}">
 	</p>
 	
 	<p><input type="submit" value="Absenden"></p>

--- a/templates/base/html/config_hardware.tpl.html
+++ b/templates/base/html/config_hardware.tpl.html
@@ -64,8 +64,8 @@ normalerweise wärend des Crawlens automatisch aufgenommen. Es besteht auch die 
 
 <h2>Neuen Chipsatz eintragen</h2>
 <form action="./config.php?section=add_hardware" method="POST">
-	<p><b>Chipsatz:</b><br><input name="name" type="text" size="30" value=""></p>
-	<p><b>Name:</b><br><input name="hardware_name" type="text" size="30" value=""></p>
+	<p><b>Chipsatz:</b><br><input name="name" type="text" size="40" value=""></p>
+	<p><b>Name:</b><br><input name="hardware_name" type="text" size="40" value=""></p>
 	
 	<p><input type="submit" value="Eintragen"></p>
 </form>


### PR DESCRIPTION
Bisher waren es nur 30 - und dies verhinderte das saubere Eintragen
eines TP-Link TL-WR841v10 in den Netmon. Teilweise auch Anpassungen auch
an den HTML-Formularen.

Bei bestehenden Netmon-Installationen muss in der DB noch ein

"ALTER TABLE chipsets CHANGE hardware_name hardware_name VARCHAR(100) NOT NULL;"

abgesetzt werden.
